### PR TITLE
common.j: note ability level field fix in 2.0.3.23025 PTR

### DIFF
--- a/common.j
+++ b/common.j
@@ -26424,7 +26424,7 @@ native BlzGetAbilityRealLevelArrayField            takes ability whichAbility, a
 native BlzGetAbilityStringLevelArrayField          takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, integer index returns string
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26434,7 +26434,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzSetAbilityBooleanField                   takes ability whichAbility, abilitybooleanfield whichField, boolean value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 For example, `ABILITY_IF_BUTTON_POSITION_NORMAL_X`.
 
 See `BlzSetAbilityStringLevelField` for test code.
@@ -26446,7 +26446,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzSetAbilityIntegerField                   takes ability whichAbility, abilityintegerfield whichField, integer value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26456,7 +26456,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzSetAbilityRealField                      takes ability whichAbility, abilityrealfield whichField, real value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 For example, `ABILITY_SF_ICON_RESEARCH`.
 See `BlzSetAbilityStringLevelField` for test code.
 
@@ -26467,7 +26467,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzSetAbilityStringField                    takes ability whichAbility, abilitystringfield whichField, string value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26488,7 +26488,7 @@ native BlzSetAbilityBooleanLevelField              takes ability whichAbility, a
 native BlzSetAbilityIntegerLevelField              takes ability whichAbility, abilityintegerlevelfield whichField, integer level, integer value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26500,7 +26500,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzSetAbilityRealLevelField                 takes ability whichAbility, abilityreallevelfield whichField, integer level, real value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26567,7 +26567,7 @@ print(BlzGetAbilityStringField(abilityB, ABILITY_SF_ICON_RESEARCH))
 native BlzSetAbilityStringLevelField               takes ability whichAbility, abilitystringlevelfield whichField, integer level, string value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26579,7 +26579,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzSetAbilityBooleanLevelArrayField         takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, integer index, boolean value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26591,7 +26591,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzSetAbilityIntegerLevelArrayField         takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer index, integer value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26603,7 +26603,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzSetAbilityRealLevelArrayField            takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, integer index, real value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26615,7 +26615,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzSetAbilityStringLevelArrayField          takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, integer index, string value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26627,7 +26627,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzAddAbilityBooleanLevelArrayField         takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, boolean value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26639,7 +26639,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzAddAbilityIntegerLevelArrayField         takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26651,7 +26651,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzAddAbilityRealLevelArrayField            takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, real value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26663,7 +26663,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzAddAbilityStringLevelArrayField          takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, string value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26675,7 +26675,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzRemoveAbilityBooleanLevelArrayField      takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, boolean value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26687,7 +26687,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzRemoveAbilityIntegerLevelArrayField      takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>
@@ -26699,7 +26699,7 @@ Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tool
 native BlzRemoveAbilityRealLevelArrayField         takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, real value returns boolean
 
 /**
-@bug v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
+@bug Fixed in PTR 2.0.3.23025; present in v2.0.3.22904, v2.0.3: per-ability instance fields sometimes wrongly apply to all ability instances of the base type.
 See `BlzSetAbilityStringLevelField` for test code.
 
 Bug report: <https://us.forums.blizzard.com/en/warcraft3/t/ability-specific-tooltip-natives-broken-in-v20322978/36601>


### PR DESCRIPTION
Tested in 2.0.3.23025, although there has been a previous PTR 2.0.3.22994